### PR TITLE
Support `base-4.17`

### DIFF
--- a/cryptohash-md5.cabal
+++ b/cryptohash-md5.cabal
@@ -48,7 +48,7 @@ source-repository head
 
 library
   default-language:  Haskell2010
-  build-depends:     base             >= 4.5   && < 4.17
+  build-depends:     base             >= 4.5   && < 4.18
                    , bytestring       >= 0.9.2 && < 0.12
 
   hs-source-dirs:    src


### PR DESCRIPTION
Tested in `persistent` via `allow-newer`