### PR TITLE
v0.11.101.0-r5: allow newer tasty-quickcheck; bump CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.19.20240416
+# version: 0.19.20240517
 #
-# REGENDATA ("0.19.20240416",["github","cabal.project"])
+# REGENDATA ("0.19.20240517",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -27,14 +27,14 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:focal
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.10.0.20240413
+          - compiler: ghc-9.10.1
             compilerKind: ghc
-            compilerVersion: 9.10.0.20240413
+            compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.2
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.4
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.6.4
+            compilerVersion: 9.6.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -101,7 +101,6 @@ jobs:
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.10.3.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
@@ -126,7 +125,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -155,18 +154,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -218,10 +205,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(cryptohash-md5)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(cryptohash-md5)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        ghc: ['9.2','9.4','9.6','9.8']
+        ghc: ['9.2','9.4','9.6','9.8','9.10']
       fail-fast: false
     timeout-minutes:
       60

--- a/cryptohash-md5.cabal
+++ b/cryptohash-md5.cabal
@@ -1,7 +1,7 @@
 cabal-version:       >=1.10
 name:                cryptohash-md5
 version:             0.11.101.0
-x-revision:          4
+x-revision:          5
 description:
     A practical incremental and one-pass, pure API to the
     <https://en.wikipedia.org/wiki/MD5 MD5 hash algorithm>
@@ -29,9 +29,9 @@ category:            Data, Cryptography
 build-type:          Simple
 
 tested-with:
-  GHC == 9.10.0
+  GHC == 9.10.1
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -41,7 +41,6 @@ tested-with:
   GHC == 8.4.4
   GHC == 8.2.2
   GHC == 8.0.2
-  -- GHC == 7.10.3
 
 extra-source-files:  cbits/md5.h
                      changelog.md
@@ -76,7 +75,7 @@ test-suite test-md5
                    , base16-bytestring >= 1.0.1.0 && < 1.1
                    , pureMD5           >= 2.1.3   && < 2.2
                    , tasty             >= 1.4     && < 1.6
-                   , tasty-quickcheck  == 0.10.*
+                   , tasty-quickcheck  >= 0.10    && < 1
                    , tasty-hunit       == 0.10.*
 
 benchmark bench-md5


### PR DESCRIPTION
Haskell-CI failure on GHC 9.10.1 is due to:
- https://github.com/haskell/entropy/issues/84

This will be fixed upstream.